### PR TITLE
Fix adsorbate typo

### DIFF
--- a/gg/data.py
+++ b/gg/data.py
@@ -249,6 +249,6 @@ adsorbate_names = {
     "imidogen": adsorbates["NH2"],
     "methyl": adsorbates["CH3"],
     "methylene": adsorbates["CH2"],
-    "methylyidyne": adsorbates["CH"],
+    "methylidyne": adsorbates["CH"],
     "formate": adsorbates["HCOO"],
 }


### PR DESCRIPTION
## Summary
- correct spelling for `methylidyne` in `adsorbate_names`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ase')*

------
https://chatgpt.com/codex/tasks/task_e_683f906350588326bfeb57e4a5d27e77