### PR TITLE
Fix command line flag formatting

### DIFF
--- a/docs/source/command_line.rst
+++ b/docs/source/command_line.rst
@@ -53,9 +53,9 @@ Base: :ref:`Add Bidentate`
    * - -max_bond / -mb
      - float
      - Fixed allowable bond distance
-   * - ---add_ads_error / -ads_err
+   * - --add_ads_error / -ads_err
      - float
      - Allowable distance between two sites for adsorption
-   * - ---norm_method / -norm_method
+   * - --norm_method / -norm_method
      - str
      - Method to calculate normals


### PR DESCRIPTION
## Summary
- fix `--add_ads_error` and `--norm_method` flags in command line docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ase')*

------
https://chatgpt.com/codex/tasks/task_e_683f907b6bec8326add07a048ee480fc