### PR TITLE
Handle optimization errors in Gcbh

### DIFF
--- a/tests/test_optimize_try_except.py
+++ b/tests/test_optimize_try_except.py
@@ -1,0 +1,29 @@
+import os
+from gg.gcbh import Gcbh
+from ase import Atoms
+from ase.calculators.emt import EMT
+
+
+def test_optimize_handles_exception(tmp_path):
+    class BoomOptimizer:
+        def __init__(self, atoms, logfile=None):
+            self.nsteps = 0
+        def run(self, fmax=None, steps=None):  # pragma: no cover - raises intentionally
+            raise RuntimeError("boom")
+
+    atoms = Atoms("H", positions=[[0, 0, 0]])
+    atoms.calc = EMT()
+
+    config = tmp_path / "config.yaml"
+    config.write_text("chemical_potential:\n  H: 0\ninitialize: false\n")
+
+    oldcwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        bh = Gcbh(atoms, config_file=str(config), optimizer=BoomOptimizer)
+        _, en = bh.optimize(atoms)
+    finally:
+        os.chdir(oldcwd)
+
+    assert bh.c["opt_on"] == -1
+    assert en < -100000


### PR DESCRIPTION
## Summary
- guard optimize routine with try/except so failed optimizations are logged and ignored
- add regression test verifying failed optimizer run is skipped

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ase'; attempted dependency installation but unable to access packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f43e2af88326a65a452f227f7d46