### PR TITLE
Apply incremental, area-normalized vibrational correction in `add_vib_correction`

### DIFF
--- a/gg/gcbh.py
+++ b/gg/gcbh.py
@@ -292,12 +292,20 @@ class Gcbh(Dynamics):
         """
         if name in self.vib_correction:
             raise RuntimeError(f"Correction: {name} exists already!\n")
+
+        previous_correction = 0
+        if self.c["vib_correction"]:
+            previous_correction = self.get_vib_correction(self.atoms)
         self.vib_correction[name] = instance
 
         # Update fe
         if self.c["vib_correction"]:
             self.logtxt(f"Updating F according to {name}")
-            self.c["fe"] += self.get_vib_correction(self.atoms)
+            total_correction = self.get_vib_correction(self.atoms)
+            correction = total_correction - previous_correction
+            correction = self._normalize_by_area(correction, self.atoms)
+            self.c["fe"] += correction
+            self.logtxt(f'Updated F after {name}: {self.c["fe"]:.6f}')
             self.c["fe_min"] = self.c["fe"]
         return
 


### PR DESCRIPTION
### Motivation

- Prevent adding the full vibrational correction repeatedly when a new correction is registered by computing only the incremental change.
- Ensure the vibrational correction contribution to `fe` is normalized by system area before being applied.
- Improve logging to make updates to `fe` visible for debugging and verification.

### Description

- Capture the previous total vibrational correction before registering the new correction by calling `get_vib_correction(self.atoms)` and storing it in `previous_correction`.
- After adding the new correction to `self.vib_correction`, compute the incremental correction as `total_correction - previous_correction` and normalize it using `_normalize_by_area` before adding it to `self.c["fe"]`.
- Add a detailed log statement `Updated F after {name}: {self.c["fe"]:.6f}` and retain the existing duplicate-name guard and `fe_min` update.

### Testing

- Ran the project's unit tests that exercise the vibrational correction path for `Gcbh.add_vib_correction`, and they passed.
- Executed the integration tests covering energy updates to ensure `fe` changes are incremental and normalized, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd40f804748326a43210f5bc2174b4)