### PR TITLE
Log external optimizer completion in main gcbh log

### DIFF
--- a/gg/gcbh.py
+++ b/gg/gcbh.py
@@ -851,6 +851,9 @@ class GcbhFlexOpt(Gcbh):
             fn = os.path.join(subdir, "opt.traj")
             assert os.path.isfile(fn)
             atoms = read(fn)
+            self.logtxt(
+                f'{get_current_time()}: Structure optimization completed for {self.c["nsteps"]}'
+            )
         finally:
             os.chdir(topdir)
         en = atoms.get_potential_energy()


### PR DESCRIPTION
### Motivation
- Ensure the completion message for structure optimizations run via an external/scripted optimizer (`GcbhFlexOpt`) is recorded in the main run log (`gcbh.log`) instead of only appearing inside the `opt_folder/opt_*` subfolder.

### Description
- Add a `self.logtxt(...)` call in `GcbhFlexOpt.optimize` (file `gg/gcbh.py`) immediately after successfully reading `opt.traj` so the message `Structure optimization completed for <step>` is written to the main log.

### Testing
- Ran `python -m py_compile gg/gcbh.py` which succeeded, confirming the module compiles.
- Ran `pytest -q tests/test_optimize_try_except.py` which failed during collection due to a missing dependency (`ModuleNotFoundError: No module named 'numpy'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7143a3b48326a3558f84d05218eb)