### PR TITLE
Defer optimization completion log until returning to top directory in optimize routines

### DIFF
--- a/gg/gcbh.py
+++ b/gg/gcbh.py
@@ -638,6 +638,7 @@ class Gcbh(Dynamics):
     def optimize(self, atoms: Atoms):
         """Optimize atoms"""
         optimizer = self.optimizer
+        completed_msg = None
         if atoms.calc is None:
             atoms.calc = self.calc
 
@@ -670,7 +671,7 @@ class Gcbh(Dynamics):
                     self.c["opt_on"] = -1
                 else:
                     atoms.write("CONTCAR", format="vasp")
-                    self.logtxt(
+                    completed_msg = (
                         f'{get_current_time()}: Structure optimization completed for {self.c["nsteps"]}'
                     )
                 en = atoms.get_potential_energy()
@@ -684,6 +685,8 @@ class Gcbh(Dynamics):
             en = -1e6
         finally:
             os.chdir(topdir)
+            if completed_msg is not None:
+                self.logtxt(completed_msg)
         return atoms, en
 
     def append_graph(self, atoms, unique_method="fullgraph"):
@@ -815,6 +818,7 @@ class GcbhFlexOpt(Gcbh):
 
     def optimize(self, atoms: Atoms):
         """Optimize atoms"""
+        completed_msg = None
 
         self.logtxt(
             f'{get_current_time()}: Begin structure optimization routine at step {self.c["nsteps"]}'
@@ -851,8 +855,13 @@ class GcbhFlexOpt(Gcbh):
             fn = os.path.join(subdir, "opt.traj")
             assert os.path.isfile(fn)
             atoms = read(fn)
+            completed_msg = (
+                f'{get_current_time()}: Structure optimization completed for {self.c["nsteps"]}'
+            )
         finally:
             os.chdir(topdir)
+            if completed_msg is not None:
+                self.logtxt(completed_msg)
         en = atoms.get_potential_energy()
         if self._reject_touching_atoms(atoms):
             en = 1e6


### PR DESCRIPTION
### Motivation

- Ensure the "Structure optimization completed" message is logged after the code returns to the main working directory to avoid writing into per-optimization subfolders. 
- Keep consistent logging behavior between `Gcbh.optimize` and `GcbhFlexOpt.optimize` and avoid side-effects from writing logs while inside `opt_*` folders.

### Description

- Introduced a `completed_msg` local variable in both `Gcbh.optimize` and `GcbhFlexOpt.optimize` to hold the completion message instead of logging it immediately. 
- Move the actual `self.logtxt(completed_msg)` call into the `finally` block after `os.chdir(topdir)` so the message is written from the top-level working directory. 
- Preserved existing energy handling and touching-atom rejection logic and made no other functional changes to optimization flow.

### Testing

- Ran the repository test suite with `pytest` and the tests completed without failures. 
- Executed the optimization routines in a local integration run to confirm the completion message is emitted from the main working directory and not from inside `opt_*` subfolders.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7143a3b48326a3558f84d05218eb)