### PR TITLE
Add progress tracking for base folder scan in get_entries_from_folders

### DIFF
--- a/gg/phase_diag.py
+++ b/gg/phase_diag.py
@@ -253,12 +253,6 @@ def get_entries_from_folders(
     mu = read_chemical_potential(mu_path)
     entries = []
     candidates = []
-    for base_folder in base_folders:
-        for root, _, files in os.walk(base_folder):
-            if file_type[0] in files and file_type[1] in files:
-                contcar_path = os.path.join(root, file_type[1])
-                en_path = os.path.join(root, file_type[0])
-                candidates.append((root, contcar_path, en_path))
 
     with Progress(
         TextColumn("{task.description}"),
@@ -266,6 +260,17 @@ def get_entries_from_folders(
         TextColumn("{task.completed}/{task.total}"),
         TimeElapsedColumn(),
     ) as progress:
+        scan_task = progress.add_task(
+            "Scanning base folders", total=len(base_folders)
+        )
+        for base_folder in base_folders:
+            for root, _, files in os.walk(base_folder):
+                if file_type[0] in files and file_type[1] in files:
+                    contcar_path = os.path.join(root, file_type[1])
+                    en_path = os.path.join(root, file_type[0])
+                    candidates.append((root, contcar_path, en_path))
+            progress.advance(scan_task)
+
         task = progress.add_task(
             "Processing phase diagram entries", total=len(candidates)
         )


### PR DESCRIPTION
### Motivation
- Provide user-visible progress when scanning multiple `base_folders` so long scans report activity before per-candidate processing begins.
- Improve UX by integrating the folder discovery phase into the existing `rich.progress` context used for per-candidate processing.

### Description
- Moved candidate discovery (`for base_folder in base_folders:`) into the existing `Progress` context in `get_entries_from_folders` (`gg/phase_diag.py`).
- Added a new `scan_task` progress task via `progress.add_task("Scanning base folders", total=len(base_folders))` and call `progress.advance(scan_task)` after each scanned base folder.
- Kept the existing `Processing phase diagram entries` task that advances per-candidate, leaving candidate processing logic unchanged.

### Testing
- Ran `pytest -q tests/test_phase_diag_vib.py`, which failed during collection with `ModuleNotFoundError: No module named 'yaml'` in this environment, so tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea811ecac08326bd83ce8912765c31)