### PR TITLE
docs: document vib_corrections usage in helper and add to toctree

### DIFF
--- a/docs/source/helper.rst
+++ b/docs/source/helper.rst
@@ -40,3 +40,34 @@ Notes:
 - ``base_folders`` can include multiple runs to combine structures into one diagram.
 - ``file_type`` should match how energies/structures are stored in your calculation outputs.
 - If you already generated entries once, set ``read_from_file`` to that JSON file path for faster re-plotting.
+
+Using ``vib_corrections``
+-------------------------
+
+You can pass ``vib_corrections`` to include approximate vibrational free-energy
+corrections for adsorbates while constructing phase entries. The value should be
+a dictionary mapping species labels (for example ``"OH"`` or ``"H"``) to configured
+modifier objects.
+
+Example:
+
+.. code-block:: python
+
+    from gg.modifiers import Remove
+    from gg.predefined_sites import FlexibleSites
+    from gg.phase_diag import plot_phase_diagram_from_run
+
+    FS2 = FlexibleSites(constraints=True, com=0.75)
+    vibOH = Remove(FS2, "OH", weight=0.20)
+    vibH = Remove(FS2, "H", weight=0.15)
+
+    fig = plot_phase_diagram_from_run(
+        "H2O",
+        "H2",
+        limits=[[-15, -10], [-10, -5]],
+        base_folders="./Mie/",
+        mu_path="./Mie/input.yaml",
+        file_type=["opt.log", "CONTCAR"],
+        vib_corrections={"OH": vibOH, "H": vibH},
+        annotate=True,
+    )

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,4 +15,5 @@ g(raph)-g(cbh) Documentation
    modifiers
    command_line
    examples
+   helper
    support


### PR DESCRIPTION
### Motivation

- Clarify how to supply `vib_corrections` to `plot_phase_diagram_from_run` so users can include approximate vibrational free-energy corrections for adsorbates when constructing phase entries.
- Ensure the new helper content is discoverable by adding it to the top-level documentation `toctree`.

### Description

- Add a "Using `vib_corrections`" subsection to `docs/source/helper.rst` that describes the expected dictionary format and provides a complete usage example with `Remove`, `FlexibleSites`, and `plot_phase_diagram_from_run`.
- Update `docs/source/index.rst` to include the new `helper` page in the documentation `toctree`.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc1889dc8832686bbc01bb5482601)